### PR TITLE
fix(index): no src folder exists in ES6 for V2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export * from "./srces6/_build";
+export * from "./es6/_build";


### PR DESCRIPTION
Running `yarn add api-ai-javascript@2.0.0-beta.14` causes the following error:

<img width="1552" alt="screen shot 2018-05-11 at 8 55 45 pm" src="https://user-images.githubusercontent.com/8507983/39952012-c09db4be-555d-11e8-864e-f73fee156e30.png">

The following fixes that! 🙌 Looks like it was looking for a src folder that doesn't exist.